### PR TITLE
Raise `ValueError` instead of `IndexError` in extract_json()

### DIFF
--- a/telescope/utils.py
+++ b/telescope/utils.py
@@ -4,7 +4,6 @@ import logging
 import textwrap
 import threading
 import urllib.parse
-from collections.abc import Mapping, Sequence
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 from itertools import chain

--- a/telescope/utils.py
+++ b/telescope/utils.py
@@ -4,6 +4,7 @@ import logging
 import textwrap
 import threading
 import urllib.parse
+from collections.abc import Mapping, Sequence
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 from itertools import chain
@@ -281,7 +282,10 @@ def extract_json(path, data):
                 istep = int(step)
             except ValueError:
                 raise ValueError(str(ke))  # Original error with step as string
-            data = data[istep]
+            try:
+                data = data[istep]
+            except IndexError:
+                raise ValueError(str(ke))  # Original error with step as string
     return data
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -61,10 +61,17 @@ def test_extract_json():
     assert extract_json(".pings.0", data) == 314
     assert extract_json(".min_timestamp", data) == "2020-09-24T10:29:44.925"
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exc_info:
         extract_json(".pings.a", data)
-    with pytest.raises(ValueError):
+    assert str(exc_info.value) == "list indices must be integers or slices, not str"
+
+    with pytest.raises(ValueError) as exc_info:
         extract_json(".field", "An error returned by check")
+    assert str(exc_info.value) == "string indices must be integers"
+
+    with pytest.raises(ValueError) as exc_info:
+        extract_json(".percentiles.75.value", {"percentiles": "No results"})
+    assert str(exc_info.value) == "string indices must be integers"
 
 
 async def test_bugzilla_fetch_fallsback_to_empty_list(mock_aioresponses, config):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -63,6 +63,7 @@ def test_extract_json():
 
     with pytest.raises(ValueError):
         extract_json(".pings.a", data)
+    with pytest.raises(ValueError):
         extract_json(".field", "An error returned by check")
 
 


### PR DESCRIPTION
We have a situation where we try to extract `.percentiles.75.value` from a dict that is `{"percentiles": "No data"}`

This raises an IndexError just because we try to convert `75` to integer in `extract_json`. For consistency, limit raised exceptions to TypeError and ValueError 