### PR TITLE
Ignore Telemetry from legacy versions in Remote Settings checks

### DIFF
--- a/checks/remotesettings/utils.py
+++ b/checks/remotesettings/utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import copy
 import random
+import re
 from typing import Dict, List, Optional, Tuple
 
 import backoff
@@ -8,7 +9,7 @@ import kinto_http
 import requests
 from kinto_http.session import USER_AGENT as KINTO_USER_AGENT
 
-from telescope import config
+from telescope import config, utils
 
 
 USER_AGENT = f"telescope {KINTO_USER_AGENT}"
@@ -228,3 +229,12 @@ def human_diff(
             f"{len(extras)} record{'s' if len(extras) > 1 else ''} present in {right} but missing in {left} ({ellipse(extras)})"
         )
     return ", ".join(details)
+
+
+async def current_firefox_esr():
+    resp = await utils.fetch_json(
+        "https://product-details.mozilla.org/1.0/firefox_versions.json"
+    )
+    version = resp["FIREFOX_ESR"]
+    # "91.0.1esr" -> (91, 0, 1)
+    return tuple(int(re.sub(r"[^\d]+", "", n)) for n in version.split("."))


### PR DESCRIPTION
The checks now ignore Telemetry from legacy versions. 

In order to include all versions, set the check parameter `include_legacy_versions` to `True`.

```toml
# config-dev.toml
[checks.remotesettings.error-rate]
description = ""
module = "checks.remotesettings.uptake_error_rate"
params.max_error_percentage = 5
params.include_legacy_versions = true
```

```
$ GOOGLE_APPLICATION_CREDENTIALS=key.json LOGGER_DEBUG=debug CONFIG_FILE=config-dev.toml make check project=remotesettings check=error-rate

{
  "sources": {
    "security-state/intermediates": {
      "error_rate": 15.52,
      "statuses": {
        "success": 871,
        "network_error": 49,
        "parse_error": 34,
        "custom_1_error": 31,
        "shutdown_error": 20,
        "offline_error": 19,
        "sync_error": 6,
        "corruption_error": 1
      },
      "ignored": {},
      "min_timestamp": "2022-01-18T09:20:00+00:00",
      "max_timestamp": "2022-01-18T09:30:00+00:00"
    },

...
...
...
`
