### PR TITLE
Fix #944: prevent NULL values to be included in quantiles

### DIFF
--- a/checks/remotesettings/uptake_max_age.py
+++ b/checks/remotesettings/uptake_max_age.py
@@ -53,10 +53,11 @@ FROM
     event_uptake_telemetry AS et,
     total_count_by_period AS tc
 WHERE et.period = tc.period
-    AND et.channel = tc.channel
+  AND et.channel = tc.channel
+  AND et.age IS NOT NULL
   -- This removes noise on periods where there is no change published.
   -- See also https://bugzilla.mozilla.org/show_bug.cgi?id=1614716
-  AND (et.channel = 'nightly' AND total > 2000) OR total > 10000
+  AND ((et.channel = 'nightly' AND total > 2000) OR total > 10000)
 GROUP BY et.channel
 """
 


### PR DESCRIPTION
The root cause of these NULL is elsewhere (see https://github.com/mozilla-services/kinto-dist/pull/1975 and https://phabricator.services.mozilla.com/D136536), but fixing this query here too does not harm.