### PR TITLE
Fix #373: Filter checks by tag

### DIFF
--- a/telescope/html/css/main-dark.css
+++ b/telescope/html/css/main-dark.css
@@ -9,8 +9,14 @@
         border-color: rgba(123, 126, 136, 0.24);
     }
 
-    .auto-theme-dark .check-tags .badge {
+    .auto-theme-dark .tags-list .badge {
         background: var(--gray-dark);
+    }
+
+    .auto-theme-dark .tags-list .badge.active {
+        background: var(--main-background);
+        color: var(--foreground-dark);
+        border-color: var(--foreground-dark);
     }
 
     .auto-theme-dark .card-footer.check-details {

--- a/telescope/html/css/main.css
+++ b/telescope/html/css/main.css
@@ -44,8 +44,14 @@ section.project:not(:first-child) {
     color: #303645;
 }
 
-.check-tags .badge {
+.tags-list .badge {
     background: var(--gray);
+}
+
+.tags-list .badge.active {
+    background: var(--main-background);
+    color: var(--foreground-dark);
+    border-color: var(--foreground-dark);
 }
 
 .check-details summary {

--- a/telescope/html/js/app/components/Check.mjs
+++ b/telescope/html/js/app/components/Check.mjs
@@ -99,7 +99,7 @@ export default class Check extends Component {
 
     if (data.tags.length) {
       tags = html`
-        <p class="check-tags lh-1">
+        <p class="tags-list lh-1">
           ${data.tags.map(
             (t) => html`<span class="badge mr-1 mb-1">${t}</span>`
           )}

--- a/telescope/html/js/app/components/CheckDetails.mjs
+++ b/telescope/html/js/app/components/CheckDetails.mjs
@@ -137,7 +137,7 @@ export default class CheckDetails extends Component {
 
     if (data.tags.length) {
       tags = html`
-        <p class="check-tags lh-1">
+        <p class="tags-list lh-1">
           ${data.tags.map(
             (t) => html`<span class="badge mr-1 mb-1">${t}</span>`
           )}

--- a/telescope/html/js/app/components/Dashboard.mjs
+++ b/telescope/html/js/app/components/Dashboard.mjs
@@ -1,9 +1,11 @@
 import { Component, html } from "../../htm_preact.mjs";
 import FocusedCheck from "../contexts/FocusedCheck.mjs";
+import SelectedTags from "../contexts/SelectedTags.mjs";
 import { ROOT_URL } from "../constants.mjs";
 
 import Overview from "./Overview.mjs";
 import Project from "./Project.mjs";
+import TagListFilter from "./TagListFilter.mjs";
 
 export default class Dashboard extends Component {
   constructor() {
@@ -19,6 +21,9 @@ export default class Dashboard extends Component {
       focusedCheck: {
         name: null,
         project: null,
+      },
+      selectedTags: {
+        tags: [],
       },
     };
   }
@@ -216,17 +221,38 @@ export default class Dashboard extends Component {
   }
 
   render() {
-    const { checks, results, focusedCheck } = this.state;
+    const { checks, results, focusedCheck, selectedTags } = this.state;
 
     const focusedCheckContext = {
       ...focusedCheck,
       setValue: this.setFocusedCheck,
     };
 
+    const selectedTagsContext = {
+      ...selectedTags,
+      add: (t) => {
+        this.setState({
+          selectedTags: {
+            tags: this.state.selectedTags.tags.concat([t]),
+          },
+        });
+      },
+      remove: (t) => {
+        this.setState({
+          selectedTags: {
+            tags: this.state.selectedTags.tags.filter((s) => s != t),
+          },
+        });
+      },
+    };
+
     return html`
       <${FocusedCheck.Provider} value="${focusedCheckContext}">
-        <${Overview} checks="${checks}" results="${results}" />
-        ${this.renderProjects()}
+        <${SelectedTags.Provider} value="${selectedTagsContext}">
+          <${Overview} checks="${checks}" results="${results}" />
+          <${TagListFilter} checks="${checks}" />
+          ${this.renderProjects()}
+        </${SelectedTags.Provider}>
       </${FocusedCheck.Provider}>
     `;
   }

--- a/telescope/html/js/app/components/Project.mjs
+++ b/telescope/html/js/app/components/Project.mjs
@@ -1,6 +1,19 @@
 import { Component, html } from "../../htm_preact.mjs";
 import FocusedCheck from "../contexts/FocusedCheck.mjs";
+import SelectedTags from "../contexts/SelectedTags.mjs";
 import Check from "./Check.mjs";
+
+function checkMatchTags(check, tags) {
+  if (tags.length == 0) {
+    return true;
+  }
+  for (const tag of tags) {
+    if (check.tags.includes(tag)) {
+      return true;
+    }
+  }
+  return false;
+}
 
 export default class Project extends Component {
   renderStatus() {
@@ -26,12 +39,21 @@ export default class Project extends Component {
       (c) => html`
         <${FocusedCheck.Consumer}>
           ${(focusedCheckContext) => html`
-            <${Check}
-              data="${c.data}"
-              result="${c.result}"
-              fetchCheckResult="${fetchCheckResult}"
-              focusedCheckContext="${focusedCheckContext}"
-            />
+            <${SelectedTags.Consumer}>
+              ${(SelectedTagsContext) => {
+                if (!checkMatchTags(c.data, SelectedTagsContext.tags)) {
+                  return "";
+                }
+                return html`
+                  <${Check}
+                    data="${c.data}"
+                    result="${c.result}"
+                    fetchCheckResult="${fetchCheckResult}"
+                    focusedCheckContext="${focusedCheckContext}"
+                  />
+                `;
+              }}
+            </${SelectedTags.Consumer}>
           `}
         </${FocusedCheck.Consumer}>
       `

--- a/telescope/html/js/app/components/Project.mjs
+++ b/telescope/html/js/app/components/Project.mjs
@@ -7,12 +7,7 @@ function checkMatchTags(check, tags) {
   if (tags.length == 0) {
     return true;
   }
-  for (const tag of tags) {
-    if (check.tags.includes(tag)) {
-      return true;
-    }
-  }
-  return false;
+  return tags.some((tag) => check.tags.includes(tag));
 }
 
 export default class Project extends Component {

--- a/telescope/html/js/app/components/Project.mjs
+++ b/telescope/html/js/app/components/Project.mjs
@@ -36,17 +36,16 @@ export default class Project extends Component {
           ${(focusedCheckContext) => html`
             <${SelectedTags.Consumer}>
               ${(SelectedTagsContext) => {
-                if (!checkMatchTags(c.data, SelectedTagsContext.tags)) {
-                  return "";
-                }
-                return html`
-                  <${Check}
-                    data="${c.data}"
-                    result="${c.result}"
-                    fetchCheckResult="${fetchCheckResult}"
-                    focusedCheckContext="${focusedCheckContext}"
-                  />
-                `;
+                return checkMatchTags(c.data, SelectedTagsContext.tags)
+                  ? html`
+                      <${Check}
+                        data="${c.data}"
+                        result="${c.result}"
+                        fetchCheckResult="${fetchCheckResult}"
+                        focusedCheckContext="${focusedCheckContext}"
+                      />
+                    `
+                  : "";
               }}
             </${SelectedTags.Consumer}>
           `}

--- a/telescope/html/js/app/components/TagListFilter.mjs
+++ b/telescope/html/js/app/components/TagListFilter.mjs
@@ -1,0 +1,49 @@
+import { Component, html } from "../../htm_preact.mjs";
+import SelectedTags from "../contexts/SelectedTags.mjs";
+
+export default class TagListFilter extends Component {
+  render({ checks }) {
+    const allTags = Array.from(
+      Object.values(checks).reduce((acc, check) => {
+        check.tags.forEach((t) => acc.add(t));
+        return acc;
+      }, new Set())
+    );
+
+    return html`
+      <div class="mt-4 mb-5 tags-list">
+        <i class="fa fa-filter" />${" "}
+        <${SelectedTags.Consumer}>
+          ${(selectedTagsContext) => html`
+            ${this.renderTagsList(allTags, selectedTagsContext)}
+          `}
+        </${SelectedTags.Consumer}>
+      </div>
+    `;
+  }
+
+  renderTagsList(tags, selectedTagsContext) {
+    if (tags.length == 0) {
+      return "";
+    }
+    return tags.map((tag) => {
+      const active = selectedTagsContext.tags.includes(tag);
+      return html`
+        <a
+          class="badge ${active ? "" : "active"}"
+          href="#"
+          onClick=${(e) => {
+            e.preventDefault();
+            if (active) {
+              selectedTagsContext.remove(tag);
+            } else {
+              selectedTagsContext.add(tag);
+            }
+          }}
+        >
+          ${tag} </a
+        >${" "}
+      `;
+    });
+  }
+}

--- a/telescope/html/js/app/components/TagListFilter.mjs
+++ b/telescope/html/js/app/components/TagListFilter.mjs
@@ -4,10 +4,7 @@ import SelectedTags from "../contexts/SelectedTags.mjs";
 export default class TagListFilter extends Component {
   render({ checks }) {
     const allTags = Array.from(
-      Object.values(checks).reduce((acc, check) => {
-        check.tags.forEach((t) => acc.add(t));
-        return acc;
-      }, new Set())
+      new Set(Object.values(checks).flatMap((c) => c.tags))
     );
 
     return html`

--- a/telescope/html/js/app/contexts/SelectedTags.mjs
+++ b/telescope/html/js/app/contexts/SelectedTags.mjs
@@ -1,0 +1,9 @@
+import { createContext } from "../../htm_preact.mjs";
+
+const SelectedTags = createContext({
+  tags: [],
+  add: () => {},
+  remove: () => {},
+});
+
+export default SelectedTags;


### PR DESCRIPTION
Fix #373

This PR adds a filter to the main page in order to filter checks by tag. 

![Screenshot from 2022-02-23 15-56-38](https://user-images.githubusercontent.com/546692/155344625-3f4e8188-59f0-45e8-8ad7-6b50f4ebe1c6.png)


