### PR TITLE
Fix #1023: do not refresh TimeAgo if details invisible

### DIFF
--- a/telescope/html/js/app/components/CheckDetails.mjs
+++ b/telescope/html/js/app/components/CheckDetails.mjs
@@ -186,7 +186,7 @@ export default class CheckDetails extends Component {
 ${JSON.stringify(result.data, null, 2)}</pre
         >
         <div class="mt-2 mb-3 text-gray-medium">
-          Updated <${TimeAgo} date="${updated}" />
+          Updated ${opened ? html`<${TimeAgo} date="${updated}" />` : updated}
         </div>
       `;
     }


### PR DESCRIPTION
I was looking at the tabs that were consuming most resources, and Telescope was one of them.

These `TimeAgo`  were refreshing the DOM for each check of the page, even if the details were invisible. This is a quick fix that does the trick