### PR TITLE
Retry failed requests after 1min

### DIFF
--- a/telescope/html/js/app/constants.mjs
+++ b/telescope/html/js/app/constants.mjs
@@ -1,3 +1,4 @@
+export const RETRY_INTERVAL = 60 * 1000;
 export const DOMAIN = window.location.href.split("/")[2];
 export const ROOT_URL = `${window.location.protocol}//${DOMAIN}`;
 


### PR DESCRIPTION
When the frontend fails to obtain a response from the server (eg. no internet connection, server returns a non-JSON response, eg. 5XX, ...), we don't want to wait for the check TTL, we want to retry the request sooner.

I defined this retry interval arbitrarily to 1min