### PR TITLE
Fix #1202: add check for responses headers

### DIFF
--- a/checks/core/headers.py
+++ b/checks/core/headers.py
@@ -1,0 +1,44 @@
+"""
+Check that certain response headers are received when certain requests headers are sent.
+
+Returns missing headers by URL if failing.
+"""
+import logging
+
+from telescope.typings import CheckResult
+from telescope.utils import fetch_head, run_parallel
+
+
+logger = logging.getLogger(__name__)
+
+
+EXPOSED_PARAMETERS = [
+    "urls",
+    "request_headers",
+    "response_headers",
+]
+
+
+async def run(
+    urls: list[str],
+    request_headers: dict[str, str],
+    response_headers: dict[str, str],
+) -> CheckResult:
+    futures = [fetch_head(url, headers=request_headers) for url in urls]
+    results = await run_parallel(*futures)
+
+    missing: dict[str, dict[str, str]] = {}
+    for url, (status, headers) in zip(urls, results):
+        for name, value in response_headers.items():
+            if name not in headers or (value and headers[name] != value):
+                missing.setdefault(url, {})[name] = value
+
+    """
+    {
+        "https://url.org": {
+            "Content-Encoding": "gzip"
+        }
+    }
+    """
+    success = not missing
+    return success, missing

--- a/tests/checks/core/test_headers.py
+++ b/tests/checks/core/test_headers.py
@@ -1,0 +1,63 @@
+from checks.core.headers import run
+
+
+async def test_positive(mock_aioresponses):
+    url = "http://server.local"
+    mock_aioresponses.head(url, status=200, headers={"Content-Encoding": "gzip"})
+
+    status, data = await run(
+        [url],
+        request_headers={},
+        response_headers={
+            "Content-Encoding": "",
+        },
+    )
+
+    assert status is True
+    assert data == {}
+
+
+async def test_negative_missing(mock_aioresponses):
+    url = "http://server.local"
+    mock_aioresponses.head(url, status=200, headers={})
+
+    status, data = await run(
+        [url],
+        request_headers={},
+        response_headers={
+            "Content-Encoding": "",
+        },
+    )
+
+    assert status is False
+    assert data == {
+        url: {
+            "Content-Encoding": "",
+        }
+    }
+
+
+async def test_negative_different(mock_aioresponses):
+    url = "http://server.local"
+    mock_aioresponses.head(
+        url,
+        status=200,
+        headers={
+            "Content-Type": "application/json",
+        },
+    )
+
+    status, data = await run(
+        [url],
+        request_headers={},
+        response_headers={
+            "Content-Encoding": "application/wasm",
+        },
+    )
+
+    assert status is False
+    assert data == {
+        url: {
+            "Content-Encoding": "application/wasm",
+        }
+    }


### PR DESCRIPTION
Fix #1202

```toml
# config-dev.toml

[checks.test.headers]
description = ""
module = "checks.core.headers"
params.urls = [
    "https://firefox-settings-attachments.cdn.mozilla.net/main-workspace/translations-wasm/3453d482-85f3-43f2-bdb9-cf86228b721b.wasm",
    "https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/translations-wasm/changeset?_expected=0",
]
params.request_headers."Accept-Encoding" = "gzip"
params.response_headers."Content-Encoding" = "gzip"


```

And run with: 
`CONFIG_FILE=config-dev.toml make check project=test check=headers` 