### PR TITLE
Update License section to reflect new repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,4 +198,4 @@ make tests
 
 ## License
 
-*Poucave* is licensed under the MPLv2. See the `LICENSE` file for details.
+*Telescope* is licensed under the MPLv2. See the `LICENSE` file for details.


### PR DESCRIPTION
It came to my attention while inspecting this project that the name of this project is referred to as **Poucave** in the _License_ section of the `README.md` file.

My assumption is that this project has changed its name between 2019-2020 from `poucave` to `telescope` and this reference was never updated.