### PR TITLE
Ref #1118: follow-up to ship curl with HTTP2 and HTTP3 support in container

### DIFF
--- a/.bandit.baseline
+++ b/.bandit.baseline
@@ -1,0 +1,178 @@
+{
+  "errors": [],
+  "generated_at": "2023-05-25T13:27:12Z",
+  "metrics": {
+    "_totals": {
+      "CONFIDENCE.HIGH": 3,
+      "CONFIDENCE.LOW": 0,
+      "CONFIDENCE.MEDIUM": 0,
+      "CONFIDENCE.UNDEFINED": 0,
+      "SEVERITY.HIGH": 0,
+      "SEVERITY.LOW": 3,
+      "SEVERITY.MEDIUM": 0,
+      "SEVERITY.UNDEFINED": 0,
+      "loc": 883,
+      "nosec": 1,
+      "skipped_tests": 0
+    },
+    "telescope/__init__.py": {
+      "CONFIDENCE.HIGH": 0,
+      "CONFIDENCE.LOW": 0,
+      "CONFIDENCE.MEDIUM": 0,
+      "CONFIDENCE.UNDEFINED": 0,
+      "SEVERITY.HIGH": 0,
+      "SEVERITY.LOW": 0,
+      "SEVERITY.MEDIUM": 0,
+      "SEVERITY.UNDEFINED": 0,
+      "loc": 0,
+      "nosec": 0,
+      "skipped_tests": 0
+    },
+    "telescope/__main__.py": {
+      "CONFIDENCE.HIGH": 0,
+      "CONFIDENCE.LOW": 0,
+      "CONFIDENCE.MEDIUM": 0,
+      "CONFIDENCE.UNDEFINED": 0,
+      "SEVERITY.HIGH": 0,
+      "SEVERITY.LOW": 0,
+      "SEVERITY.MEDIUM": 0,
+      "SEVERITY.UNDEFINED": 0,
+      "loc": 3,
+      "nosec": 0,
+      "skipped_tests": 0
+    },
+    "telescope/app.py": {
+      "CONFIDENCE.HIGH": 3,
+      "CONFIDENCE.LOW": 0,
+      "CONFIDENCE.MEDIUM": 0,
+      "CONFIDENCE.UNDEFINED": 0,
+      "SEVERITY.HIGH": 0,
+      "SEVERITY.LOW": 3,
+      "SEVERITY.MEDIUM": 0,
+      "SEVERITY.UNDEFINED": 0,
+      "loc": 380,
+      "nosec": 0,
+      "skipped_tests": 0
+    },
+    "telescope/config.py": {
+      "CONFIDENCE.HIGH": 0,
+      "CONFIDENCE.LOW": 0,
+      "CONFIDENCE.MEDIUM": 0,
+      "CONFIDENCE.UNDEFINED": 0,
+      "SEVERITY.HIGH": 0,
+      "SEVERITY.LOW": 0,
+      "SEVERITY.MEDIUM": 0,
+      "SEVERITY.UNDEFINED": 0,
+      "loc": 89,
+      "nosec": 1,
+      "skipped_tests": 0
+    },
+    "telescope/middleware.py": {
+      "CONFIDENCE.HIGH": 0,
+      "CONFIDENCE.LOW": 0,
+      "CONFIDENCE.MEDIUM": 0,
+      "CONFIDENCE.UNDEFINED": 0,
+      "SEVERITY.HIGH": 0,
+      "SEVERITY.LOW": 0,
+      "SEVERITY.MEDIUM": 0,
+      "SEVERITY.UNDEFINED": 0,
+      "loc": 43,
+      "nosec": 0,
+      "skipped_tests": 0
+    },
+    "telescope/typings.py": {
+      "CONFIDENCE.HIGH": 0,
+      "CONFIDENCE.LOW": 0,
+      "CONFIDENCE.MEDIUM": 0,
+      "CONFIDENCE.UNDEFINED": 0,
+      "SEVERITY.HIGH": 0,
+      "SEVERITY.LOW": 0,
+      "SEVERITY.MEDIUM": 0,
+      "SEVERITY.UNDEFINED": 0,
+      "loc": 4,
+      "nosec": 0,
+      "skipped_tests": 0
+    },
+    "telescope/utils.py": {
+      "CONFIDENCE.HIGH": 0,
+      "CONFIDENCE.LOW": 0,
+      "CONFIDENCE.MEDIUM": 0,
+      "CONFIDENCE.UNDEFINED": 0,
+      "SEVERITY.HIGH": 0,
+      "SEVERITY.LOW": 0,
+      "SEVERITY.MEDIUM": 0,
+      "SEVERITY.UNDEFINED": 0,
+      "loc": 364,
+      "nosec": 0,
+      "skipped_tests": 0
+    }
+  },
+  "results": [
+    {
+      "code": "5 import os\n6 import subprocess\n7 import time\n",
+      "col_offset": 0,
+      "end_col_offset": 17,
+      "filename": "telescope/app.py",
+      "issue_confidence": "HIGH",
+      "issue_cwe": {
+        "id": 78,
+        "link": "https://cwe.mitre.org/data/definitions/78.html"
+      },
+      "issue_severity": "LOW",
+      "issue_text": "Consider possible security implications associated with the subprocess module.",
+      "line_number": 6,
+      "line_range": [
+        6
+      ],
+      "more_info": "https://bandit.readthedocs.io/en/1.7.5/blacklists/blacklist_imports.html#b404-import-subprocess",
+      "test_id": "B404",
+      "test_name": "blacklist"
+    },
+    {
+      "code": "218     # Check that `curl` has HTTP2 and HTTP3 for `checks.core.http_versions`\n219     curl_cmd = subprocess.run(\n220         [\"curl\", \"--version\"],\n221         capture_output=True,\n222     )\n223     output = curl_cmd.stdout.strip().decode()\n",
+      "col_offset": 15,
+      "end_col_offset": 5,
+      "filename": "telescope/app.py",
+      "issue_confidence": "HIGH",
+      "issue_cwe": {
+        "id": 78,
+        "link": "https://cwe.mitre.org/data/definitions/78.html"
+      },
+      "issue_severity": "LOW",
+      "issue_text": "Starting a process with a partial executable path",
+      "line_number": 219,
+      "line_range": [
+        219,
+        220,
+        221,
+        222
+      ],
+      "more_info": "https://bandit.readthedocs.io/en/1.7.5/plugins/b607_start_process_with_partial_path.html",
+      "test_id": "B607",
+      "test_name": "start_process_with_partial_path"
+    },
+    {
+      "code": "218     # Check that `curl` has HTTP2 and HTTP3 for `checks.core.http_versions`\n219     curl_cmd = subprocess.run(\n220         [\"curl\", \"--version\"],\n221         capture_output=True,\n222     )\n223     output = curl_cmd.stdout.strip().decode()\n",
+      "col_offset": 15,
+      "end_col_offset": 5,
+      "filename": "telescope/app.py",
+      "issue_confidence": "HIGH",
+      "issue_cwe": {
+        "id": 78,
+        "link": "https://cwe.mitre.org/data/definitions/78.html"
+      },
+      "issue_severity": "LOW",
+      "issue_text": "subprocess call - check for execution of untrusted input.",
+      "line_number": 219,
+      "line_range": [
+        219,
+        220,
+        221,
+        222
+      ],
+      "more_info": "https://bandit.readthedocs.io/en/1.7.5/plugins/b603_subprocess_without_shell_equals_true.html",
+      "test_id": "B603",
+      "test_name": "subprocess_without_shell_equals_true"
+    }
+  ]
+}

--- a/.bandit.baseline
+++ b/.bandit.baseline
@@ -1,6 +1,6 @@
 {
   "errors": [],
-  "generated_at": "2023-05-25T13:27:12Z",
+  "generated_at": "2023-05-25T13:28:03Z",
   "metrics": {
     "_totals": {
       "CONFIDENCE.HIGH": 3,

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,12 +21,21 @@ jobs:
       - checkout
 
       - run:
+          name: Get curl with HTTP2 and HTTP3 support
+          command: |
+            wget https://github.com/stunnel/static-curl/releases/download/8.1.1/curl-static-amd64-8.1.1.tar.xz
+            tar -xvf curl-*.tar.xz
+            mv curl /home/circleci/.local/bin/curl
+
+      - run:
           name: Use latest poetry
           command: curl -sSL https://install.python-poetry.org | python3 -
 
       - run:
           name: Test
           command: make tests
+          environment:
+            CURL_BINARY_PATH: /home/circleci/.local/bin/curl
 
   docker-build-test-publish:
     docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,75 @@
-FROM python:3.11-slim-buster
+#
+# Static build of `curl` with both HTTP2 and HTTP3 support.
+#
+# This was adapted from stunnel's script:
+# https://github.com/stunnel/static-curl/blob/f8a20698bd39b6/build.sh
+#
+FROM alpine AS buildcurl
+
+RUN apk update && \
+    apk add \
+        build-base clang automake cmake autoconf libtool linux-headers git \
+        binutils cunit-dev
+
+ENV PREFIX=/opt/curl
+ENV PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig:$PREFIX/lib64/pkgconfig:$PKG_CONFIG_PATH
+
+RUN git clone --depth 1 -b openssl-3.0.8+quic https://github.com/quictls/openssl && \
+    cd openssl && \
+    mkdir -p "${PREFIX}/lib/" "${PREFIX}/lib64/" "${PREFIX}/include/" && \
+    ./config -fPIC --prefix="${PREFIX}" \
+        threads no-shared enable-tls1_3 && \
+    make -j $(nproc) && \
+    make install_sw && \
+    cd ..
+
+RUN git clone -b v0.11.0 https://github.com/ngtcp2/nghttp3 && \
+    cd nghttp3 && \
+    autoreconf -i --force && \
+    PKG_CONFIG="pkg-config --static --with-path=$PREFIX/lib/pkgconfig" \
+        ./configure --prefix="${PREFIX}" --enable-static --enable-shared=no --enable-lib-only && \
+    make -j $(nproc) && \
+    make install && \
+    cd ..
+
+RUN git clone -b v0.15.0 https://github.com/ngtcp2/ngtcp2 && \
+    cd ngtcp2 && \
+    autoreconf -i --force && \
+    PKG_CONFIG="pkg-config --static --with-path=${PREFIX}/lib/pkgconfig:${PREFIX}/lib64/pkgconfig" \
+        ./configure --prefix="${PREFIX}" --enable-static --with-openssl=${PREFIX} \
+            --with-libnghttp3=${PREFIX} --enable-lib-only --enable-shared=no && \
+    make -j $(nproc) check && \
+    make install && \
+    cd ..
+
+RUN git clone https://github.com/nghttp2/nghttp2 && \
+    cd nghttp2 && \
+    autoreconf -i --force && \
+    PKG_CONFIG="pkg-config --static --with-path=$PREFIX/lib/pkgconfig" \
+        ./configure --prefix="${PREFIX}" --enable-static --enable-http3 \
+            --enable-lib-only --enable-shared=no && \
+    make -j $(nproc) check && \
+    make install && \
+    cd ..
+
+RUN git clone https://github.com/curl/curl && \
+    cd curl && \
+    autoreconf -i --force && \
+    PKG_CONFIG="pkg-config --static" \
+        ./configure --prefix="${PREFIX}" \
+            --disable-shared --enable-static \
+             --with-openssl \
+             --with-nghttp2 --with-nghttp3 --with-ngtcp2 && \
+    make -j $(nproc) V=1 LDFLAGS="-L${PREFIX}/lib -L${PREFIX}/lib64 -static -all-static" CFLAGS="-O3" && \
+    make install && \
+    # We now have a static binary of curl at `${PREFIX}/bin/curl`
+    cd ..
+
+
+#
+# Production container.
+#
+FROM python:3.11-slim-buster AS production
 
 WORKDIR /app
 
@@ -6,19 +77,14 @@ RUN groupadd --gid 10001 app \
     && useradd -m -g app --uid 10001 -s /usr/sbin/nologin app
 
 RUN apt-get update && \
-    apt-get install --yes --no-install-recommends wget build-essential libssl-dev && \
+    apt-get install --yes --no-install-recommends build-essential && \
     pip install --progress-bar=off -U pip && \
     pip install poetry && \
-    # curl with http3 support
-    wget https://curl.se/download/curl-8.1.1.tar.gz && \
-    tar -xvf curl-*.tar.gz && cd curl-* && \
-    ./configure --with-openssl --disable-shared && make && make install && \
-    cd .. && \
-    # cleanup
     apt-get -q --yes autoremove && \
     apt-get clean && \
     rm -rf /root/.cache
 
+COPY --from=buildcurl /opt/curl/bin/curl /usr/local/bin/curl
 COPY ./pyproject.toml /app
 COPY ./poetry.lock /app
 

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ lint: $(INSTALL_STAMP)  ## Analyze code base
 	$(POETRY) run black --check checks tests $(NAME) --diff
 	$(POETRY) run flake8 --ignore=W503,E501 checks tests $(NAME)
 	$(POETRY) run mypy checks tests $(NAME) --ignore-missing-imports
-	$(POETRY) run bandit -r $(NAME) -s B608
+	$(POETRY) run bandit -r $(NAME) -b .bandit.baseline
 	$(POETRY) run poetry run detect-secrets-hook `git ls-files | grep -v poetry.lock` --baseline .secrets.baseline
 
 format: $(INSTALL_STAMP)  ## Format code base

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Server configuration is done via environment variables:
 
 * ``GITHUB_TOKEN``: Github [Personal Access Token value](https://github.com/settings/tokens) to avoid rate-limiting (default: disabled)
 * ``GOOGLE_APPLICATION_CREDENTIALS``: Absolute path to credentials file for BigQuery authentication (eg. `` `pwd`/key.json``, default: disabled)
+* ``CURL_BINARY_PATH``: path to ``curl`` command (default: ``curl``)
 
 Configuration can be stored in a ``.env`` file:
 

--- a/checks/core/http_versions.py
+++ b/checks/core/http_versions.py
@@ -3,6 +3,7 @@ URL should support the specified versions.
 """
 import subprocess
 
+from telescope import config
 from telescope.typings import CheckResult
 
 
@@ -15,7 +16,15 @@ async def run(url: str, versions: list[str] = ["1", "1.1", "2", "3"]) -> CheckRe
     supported_versions = set()
     for flag in CURL_VERSION_FLAGS:
         result = subprocess.run(
-            ["curl", "-sI", flag, url, "-o/dev/null", "-w", "%{http_version}\n"],
+            [
+                config.CURL_BINARY_PATH,
+                "-sI",
+                flag,
+                url,
+                "-o/dev/null",
+                "-w",
+                "%{http_version}\n",
+            ],
             capture_output=True,
         )
         supported_versions.add(result.stdout.strip().decode())

--- a/telescope/app.py
+++ b/telescope/app.py
@@ -217,7 +217,7 @@ async def heartbeat(request):
     checks = {}
     # Check that `curl` has HTTP2 and HTTP3 for `checks.core.http_versions`
     curl_cmd = subprocess.run(
-        ["curl", "--version"],
+        [config.CURL_BINARY_PATH, "--version"],
         capture_output=True,
     )
     output = curl_cmd.stdout.strip().decode()

--- a/telescope/app.py
+++ b/telescope/app.py
@@ -3,6 +3,7 @@ import importlib
 import json
 import logging.config
 import os
+import subprocess
 import time
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -213,7 +214,21 @@ async def lbheartbeat(request):
 
 @routes.get("/__heartbeat__")
 async def heartbeat(request):
-    return web.json_response({})
+    checks = {}
+    # Check that `curl` has HTTP2 and HTTP3 for `checks.core.http_versions`
+    curl_cmd = subprocess.run(
+        ["curl", "--version"],
+        capture_output=True,
+    )
+    output = curl_cmd.stdout.strip().decode()
+    missing_features = [f for f in ("HTTP2", "HTTP3", "SSL") if f not in output]
+    checks["curl"] = (
+        "ok"
+        if not missing_features
+        else f"missing features {', '.join(missing_features)}"
+    )
+    status = 200 if all(v == "ok" for v in checks.values()) else 503
+    return web.json_response(checks, status=status)
 
 
 @routes.get("/__version__")

--- a/telescope/config.py
+++ b/telescope/config.py
@@ -73,6 +73,7 @@ LOGGING = {
         "check.result": {"handlers": ["console"], "level": "INFO"},
     },
 }
+CURL_BINARY_PATH = config("CURL_BINARY_PATH", default="curl")
 
 
 def interpolate_env(d):

--- a/tests/test_basic_endpoints.py
+++ b/tests/test_basic_endpoints.py
@@ -36,6 +36,8 @@ async def test_lbheartbeat(cli):
 async def test_heartbeat(cli):
     response = await cli.get("/__heartbeat__")
     assert response.status == 200
+    body = await response.json()
+    assert body["curl"] == "ok"
 
 
 async def test_version(cli):


### PR DESCRIPTION
In this PR we build `curl` statically with http2 and http3 support.

We add a `bandit` baseline file, because bandit warns us about using `subprocess.call()`

For CircleCI, where we also run the tests on the host itself, we download a binary from the internet