### PR TITLE
Mention TROUBLESHOOTING_LINK_TEMPLATE in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Server configuration is done via environment variables:
 * ``GITHUB_TOKEN``: Github [Personal Access Token value](https://github.com/settings/tokens) to avoid rate-limiting (default: disabled)
 * ``GOOGLE_APPLICATION_CREDENTIALS``: Absolute path to credentials file for BigQuery authentication (eg. `` `pwd`/key.json``, default: disabled)
 * ``CURL_BINARY_PATH``: path to ``curl`` command (default: ``curl``)
-* ``TROUBLESHOOTING_LINK_TEMPLATE``: Pattern for troubleshooting links, with `{project}` and `{check}` placeholders (default: ``https://wiki.company.com/troubleshooting.html#{project}/{check}``)
+* ``TROUBLESHOOTING_LINK_TEMPLATE``: Pattern for troubleshooting links, with `{project}` and `{check}` placeholders (default: ``https://wiki.example.com/troubleshooting.html#{project}/{check}``)
 
 Configuration can be stored in a ``.env`` file:
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Server configuration is done via environment variables:
 * ``GITHUB_TOKEN``: Github [Personal Access Token value](https://github.com/settings/tokens) to avoid rate-limiting (default: disabled)
 * ``GOOGLE_APPLICATION_CREDENTIALS``: Absolute path to credentials file for BigQuery authentication (eg. `` `pwd`/key.json``, default: disabled)
 * ``CURL_BINARY_PATH``: path to ``curl`` command (default: ``curl``)
+* ``TROUBLESHOOTING_LINK_TEMPLATE``: Pattern for troubleshooting links, with `{project}` and `{check}` placeholders (default: ``https://wiki.company.com/troubleshooting.html#{project}/{check}``)
 
 Configuration can be stored in a ``.env`` file:
 

--- a/telescope/config.py
+++ b/telescope/config.py
@@ -38,10 +38,7 @@ SOURCE_URL = config(
 )
 TROUBLESHOOTING_LINK_TEMPLATE = config(
     "TROUBLESHOOTING_LINK_TEMPLATE",
-    default=(
-        "https://mana.mozilla.org/wiki/pages/viewpage.action?pageId=126619112"
-        "#TroubleshootingRemoteSettings&Normandy-{project}/{check}"
-    ),
+    default="https://wiki.company.com/troubleshooting.html#{project}/{check}",
 )
 VERSION_FILE = config("VERSION_FILE", default="version.json")
 LOG_LEVEL = config("LOG_LEVEL", default="INFO").upper()

--- a/telescope/config.py
+++ b/telescope/config.py
@@ -38,7 +38,7 @@ SOURCE_URL = config(
 )
 TROUBLESHOOTING_LINK_TEMPLATE = config(
     "TROUBLESHOOTING_LINK_TEMPLATE",
-    default="https://wiki.company.com/troubleshooting.html#{project}/{check}",
+    default="https://wiki.example.com/troubleshooting.html#{project}/{check}",
 )
 VERSION_FILE = config("VERSION_FILE", default="version.json")
 LOG_LEVEL = config("LOG_LEVEL", default="INFO").upper()

--- a/tests/test_basic_endpoints.py
+++ b/tests/test_basic_endpoints.py
@@ -71,7 +71,7 @@ async def test_checks(cli):
             "tags": ["ops", "test"],
             "ttl": 60,
             "troubleshooting": (
-                "https://wiki.company.com/troubleshooting.html#testproject/hb"
+                "https://wiki.example.com/troubleshooting.html#testproject/hb"
             ),
             "parameters": {"url": "http://server.local/__heartbeat__"},
         }
@@ -164,7 +164,7 @@ testproject  hb
       "ok": false
     }
   Troubleshooting:
-    https://wiki.company.com/troubleshooting.html#testproject/hb"""
+    https://wiki.example.com/troubleshooting.html#testproject/hb"""
     )
 
 

--- a/tests/test_basic_endpoints.py
+++ b/tests/test_basic_endpoints.py
@@ -71,8 +71,7 @@ async def test_checks(cli):
             "tags": ["ops", "test"],
             "ttl": 60,
             "troubleshooting": (
-                "https://mana.mozilla.org/wiki/pages/viewpage.action?pageId=126619112"
-                "#TroubleshootingRemoteSettings&Normandy-testproject/hb"
+                "https://wiki.company.com/troubleshooting.html#testproject/hb"
             ),
             "parameters": {"url": "http://server.local/__heartbeat__"},
         }
@@ -165,7 +164,7 @@ testproject  hb
       "ok": false
     }
   Troubleshooting:
-    https://mana.mozilla.org/wiki/pages/viewpage.action?pageId=126619112#TroubleshootingRemoteSettings&Normandy-testproject/hb"""
+    https://wiki.company.com/troubleshooting.html#testproject/hb"""
     )
 
 


### PR DESCRIPTION
The default URL used to point to a real wiki page at Mozilla, that is now 404.

We realized that the setting was not documented in the README.

Instead of having such a Mozilla-specific default value, we decided to set its default value to a dummy URL so that its more obvious that it has to be customized