### PR TITLE
Add ability to filter by multiple tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Cache can be forced to be refreshed with the ``?refresh={s3cr3t}`` querystring. 
 * ``/checks``: list all checks, without executing them.
 * ``/checks/{a-project}``: execute all checks of project ``a-project``
 * ``/checks/tags/{a-tag}``: execute all checks with tag ``a-tag``
+* ``/checks/tags/{tag1}+{tag2}``: execute all checks having both tags ``tag1`` and ``tag2``
 
 Output format:
 

--- a/telescope/app.py
+++ b/telescope/app.py
@@ -42,7 +42,7 @@ class Checks:
         self,
         project: Optional[str] = None,
         name: Optional[str] = None,
-        tag: Optional[str] = None,
+        tags: Optional[str] = None,
     ):
         selected = self.all
 
@@ -56,10 +56,11 @@ class Checks:
             if len(selected) == 0:
                 raise ValueError(f"Unknown check '{project}.{name}'")
 
-        elif tag is not None:
-            selected = [c for c in selected if tag in c.tags]
+        elif tags is not None:
+            tags = tags.split("+")
+            selected = [c for c in selected if set(tags).issubset(set(c.tags))]
             if len(selected) == 0:
-                raise ValueError(f"No check with tag '{tag}'")
+                raise ValueError(f"No check with tags '{tags}'")
 
         return selected
 
@@ -268,7 +269,7 @@ async def project_checkpoints(request):
     )
 
 
-@routes.get("/checks/tags/{tag}")
+@routes.get("/checks/tags/{tags}")
 @utils.render_checks
 async def tags_checkpoints(request):
     checks = request.app["telescope.checks"]

--- a/tests/config.toml
+++ b/tests/config.toml
@@ -15,7 +15,7 @@ params.from_conf = 100
 description = "Test plot"
 module = "checks.core.heartbeat"
 params.url = "http://server.local/__heartbeat__"
-tags = [ "critical" ]
+tags = [ "test", "critical" ]
 plot = ".field"
 
 [checks.project.env]

--- a/tests/test_basic_endpoints.py
+++ b/tests/test_basic_endpoints.py
@@ -123,7 +123,7 @@ async def test_project_returns_only_cached(mock_aioresponses, cli):
     assert body[1]["data"] == {"max_age": 999, "from_conf": 100}
 
 
-# /tags/{tag}
+# /tags/{tags}
 
 
 async def test_check_tag_unknown(cli):
@@ -131,7 +131,7 @@ async def test_check_tag_unknown(cli):
     assert response.status == 404
 
 
-async def test_check_by_tag(cli, mock_aioresponses):
+async def test_check_by_tags(cli, mock_aioresponses):
     mock_aioresponses.get(
         "http://server.local/__heartbeat__", status=200, payload={"ok": True}
     )
@@ -139,7 +139,18 @@ async def test_check_by_tag(cli, mock_aioresponses):
     assert response.status == 200
 
 
-async def test_check_by_tag_text_mode(cli, mock_aioresponses):
+async def test_check_by_multiple_tags(cli, mock_aioresponses):
+    mock_aioresponses.get(
+        "http://server.local/__heartbeat__", status=200, payload={"ok": True}
+    )
+    response = await cli.get("/checks/tags/ops+test")
+    assert response.status == 200
+    body = await response.json()
+    # Only one check has "ops" and "test" tags in `config.toml`
+    assert len(body) == 1
+
+
+async def test_check_by_tags_text_mode(cli, mock_aioresponses):
     mock_aioresponses.get(
         "http://server.local/__heartbeat__", status=500, payload={"ok": False}
     )
@@ -371,7 +382,7 @@ async def test_logging_result(caplog, cli, mock_aioresponses):
     assert result_logs[0].success
     assert result_logs[0].project == "project"
     assert result_logs[0].check == "plot"
-    assert result_logs[0].tags == ["critical"]
+    assert result_logs[0].tags == ["test", "critical"]
     assert result_logs[0].plot == 12
 
     assert result_logs[1].plot is None


### PR DESCRIPTION
When we worked on https://github.com/mozilla-services/telescope/issues/1239 we realized it would be interesting to be able to filter checks that contain both `remotesettings-critical` and `prod`. It's more elegant than adding a `remotesettings-critical-{envName}` tag