### PR TITLE
Do not log querystrings in request.summary logs

### DIFF
--- a/telescope/config.py
+++ b/telescope/config.py
@@ -44,6 +44,7 @@ TROUBLESHOOTING_LINK_TEMPLATE = config(
 VERSION_FILE = config("VERSION_FILE", default="version.json")
 LOG_LEVEL = config("LOG_LEVEL", default="INFO").upper()
 LOG_FORMAT = config("LOG_FORMAT", default="json")
+LOG_SUMMARY_QUERYSTRING = config("LOG_SUMMARY_QUERYSTRING", default=False)
 LOGGING = {
     "version": 1,
     "formatters": {

--- a/telescope/middleware.py
+++ b/telescope/middleware.py
@@ -7,6 +7,8 @@ from secrets import token_hex
 from aiohttp import web
 from aiohttp.web import middleware
 
+from . import config
+
 
 logger = logging.getLogger(__name__)
 summary_logger = logging.getLogger("request.summary")
@@ -21,10 +23,12 @@ async def request_summary(request, handler):
         "path": str(request.rel_url),
         "method": request.method,
         "lang": request.headers.get("Accept-Language"),
-        "querystring": dict(request.query),
         "errno": 0,
         "rid": request.headers.get("X-Request-Id", token_hex(16)),
     }
+
+    if config.LOG_SUMMARY_QUERYSTRING:
+        infos["querystring"] = dict(request.query)
 
     response = await handler(request)
 

--- a/tests/test_basic_endpoints.py
+++ b/tests/test_basic_endpoints.py
@@ -356,6 +356,25 @@ async def test_sends_events(mock_aioresponses, cli):
     ]
 
 
+async def test_logging_summary_no_querystring_by_default(caplog, cli):
+    caplog.set_level(logging.INFO, logger="request.summary")
+
+    await cli.get("/?foo=bar")
+
+    [summary_log] = [log for log in caplog.records if log.name == "request.summary"]
+    assert not hasattr(summary_log, "querystring")
+
+
+async def test_logging_summary_with_querystring_if_enabled(caplog, config, cli):
+    caplog.set_level(logging.INFO, logger="request.summary")
+    config.LOG_SUMMARY_QUERYSTRING = True
+
+    await cli.get("/?foo=bar")
+
+    [summary_log] = [log for log in caplog.records if log.name == "request.summary"]
+    assert summary_log.querystring == {"foo": "bar"}
+
+
 async def test_logging_result(caplog, cli, mock_aioresponses):
     cli.app["telescope.cache"] = None
     caplog.set_level(logging.INFO, logger="check.result")


### PR DESCRIPTION
Since querystring fields are turned into columns in our log ingestion pipeline, we don't want to log querystrings by default.

Alternative option: serialize querystrings into strings and log them always
