### PR TITLE
Fix #1440: use product details API to filter old clients in spike check

### DIFF
--- a/checks/remotesettings/uptake_spikes.py
+++ b/checks/remotesettings/uptake_spikes.py
@@ -9,7 +9,9 @@ The min/max timestamps give the datetime range of the obtained dataset.
 """
 
 from collections import defaultdict
+from typing import Optional
 
+from checks.remotesettings.utils import current_firefox_esr
 from telescope.typings import CheckResult
 from telescope.utils import fetch_bigquery
 
@@ -73,8 +75,16 @@ async def run(
     max_total: int,
     period_hours: int = 48,  # inspect last 48H
     period_sampling_seconds: int = 600,  # on periods of 10min
-    min_version: int = 91,
+    min_version: Optional[int] = None,
+    include_legacy_versions: bool = False,
 ) -> CheckResult:
+    if min_version is None:
+        if include_legacy_versions:
+            min_version = 91
+        else:
+            current_esr = await current_firefox_esr()
+            min_version = current_esr[0]
+
     rows = await fetch_bigquery(
         EVENTS_TELEMETRY_QUERY.format(
             status=status,

--- a/tests/checks/remotesettings/test_uptake_spikes.py
+++ b/tests/checks/remotesettings/test_uptake_spikes.py
@@ -74,3 +74,13 @@ async def test_filter_on_legacy_versions_by_default(mock_aioresponses):
 
     [[call_args, _]] = mocked.call_args_list
     assert "WHERE SAFE_CAST(version AS INTEGER) >= 115" in call_args[0]
+
+
+async def test_can_include_legacy_versions():
+    with patch_async(f"{MODULE}.fetch_bigquery", return_value=FAKE_ROWS) as mocked:
+        await run(
+            status="sign_retry_error", max_total=1000, include_legacy_versions=True
+        )
+
+    [[call_args, _]] = mocked.call_args_list
+    assert "WHERE SAFE_CAST(version AS INTEGER) >= 91" in call_args[0]

--- a/tests/checks/remotesettings/test_uptake_spikes.py
+++ b/tests/checks/remotesettings/test_uptake_spikes.py
@@ -57,3 +57,20 @@ async def test_negative():
         status, data = await run(status="sign_retry_error", max_total=200)
 
     assert status is False
+
+
+async def test_filter_on_legacy_versions_by_default(mock_aioresponses):
+    url_versions = "https://product-details.mozilla.org/1.0/firefox_versions.json"
+    mock_aioresponses.get(
+        url_versions,
+        payload={
+            "FIREFOX_DEVEDITION": "127.0b4",
+            "FIREFOX_ESR": "115.0.1esr",
+            "FIREFOX_NIGHTLY": "128.0a1",
+        },
+    )
+    with patch_async(f"{MODULE}.fetch_bigquery", return_value=FAKE_ROWS) as mocked:
+        await run(status="sign_retry_error", max_total=1000)
+
+    [[call_args, _]] = mocked.call_args_list
+    assert "WHERE SAFE_CAST(version AS INTEGER) >= 115" in call_args[0]


### PR DESCRIPTION
Fix #1440