### PR TITLE
Fixes #1457 and #1423 - Resolving bugzilla fetch issues and adding bugzilla ping to heartbeat

### DIFF
--- a/telescope/app.py
+++ b/telescope/app.py
@@ -229,11 +229,7 @@ async def heartbeat(request):
         else f"missing features {', '.join(missing_features)}"
     )
     bz_ping = await request.app["telescope.tracker"].ping()
-    checks["bugzilla"] = (
-        "ok"
-        if bz_ping
-        else "Bugzilla ping failed"
-    )
+    checks["bugzilla"] = "ok" if bz_ping else "Bugzilla ping failed"
     status = 200 if all(v == "ok" for v in checks.values()) else 503
     return web.json_response(checks, status=status)
 

--- a/telescope/app.py
+++ b/telescope/app.py
@@ -228,6 +228,12 @@ async def heartbeat(request):
         if not missing_features
         else f"missing features {', '.join(missing_features)}"
     )
+    bz_ping = await request.app["telescope.tracker"].ping()
+    checks["bugzilla"] = (
+        "ok"
+        if bz_ping
+        else "Bugzilla ping failed"
+    )
     status = 200 if all(v == "ok" for v in checks.values()) else 503
     return web.json_response(checks, status=status)
 

--- a/telescope/utils.py
+++ b/telescope/utils.py
@@ -301,12 +301,14 @@ class BugTracker:
 
     async def ping(self) -> bool:
         """
-        Returns True if we can succesfully hit and parse the /rest/version endpoint.
+        Returns True if we can succesfully hit and parse the /rest/whoami endpoint.
         """
-        url = f"{config.BUGTRACKER_URL}/rest/version"
+        url = f"{config.BUGTRACKER_URL}/rest/whoami"
         try:
-            version = await fetch_json(url)
-            return "version" in version
+            response = await fetch_json(
+                url, headers={"X-BUGZILLA-API-KEY": config.BUGTRACKER_API_KEY}
+            )
+            return "name" in response
         except Exception as e:
             logger.exception(e)
             return False

--- a/telescope/utils.py
+++ b/telescope/utils.py
@@ -334,7 +334,7 @@ class BugTracker:
             if buglist is None:
                 # Fallback to an empty list when fetching fails. Caching this fallback value
                 # will prevent every check to fail because of the bugtracker.
-                default_buglist = {"bugs": []}
+                default_buglist: Dict = {"bugs": []}
                 env_name = config.ENV_NAME or ""
                 url = f"{config.BUGTRACKER_URL}/rest/bug?whiteboard={config.SERVICE_NAME} {env_name}"
                 try:
@@ -345,7 +345,7 @@ class BugTracker:
                 except aiohttp.ClientError as e:
                     logger.exception(e)
                     buglist = default_buglist
-                    
+
                 if self.cache:
                     self.cache.set(cache_key, buglist, ttl=config.BUGTRACKER_TTL)
 

--- a/telescope/utils.py
+++ b/telescope/utils.py
@@ -299,6 +299,19 @@ class BugTracker:
     def __init__(self, cache=None):
         self.cache = cache
 
+    async def ping(self) -> bool:
+        """
+        Returns True if we can succesfully hit and parse the /rest/version endpoint.
+        """
+        url = f"{config.BUGTRACKER_URL}/rest/version"
+        try:
+            version = await fetch_json(url)
+            return "version" in version
+        except Exception as e:
+            print(e)
+            logger.exception(e)
+            return False
+
     async def fetch(self, project: str, name: str) -> List[BugInfo]:
         """
         Fetch the list of bugs associated with the specified {project}/{name}.

--- a/telescope/utils.py
+++ b/telescope/utils.py
@@ -308,7 +308,6 @@ class BugTracker:
             version = await fetch_json(url)
             return "version" in version
         except Exception as e:
-            print(e)
             logger.exception(e)
             return False
 

--- a/telescope/utils.py
+++ b/telescope/utils.py
@@ -324,7 +324,7 @@ class BugTracker:
                     buglist = await fetch_json(
                         url, headers={"X-BUGZILLA-API-KEY": config.BUGTRACKER_API_KEY}
                     )
-                except aiohttp.ClientError as e:
+                except Exception as e:
                     logger.exception(e)
                     # Fallback to an empty list when fetching fails. Caching this fallback value
                     # will prevent every check to fail because of the bugtracker.

--- a/tests/test_basic_endpoints.py
+++ b/tests/test_basic_endpoints.py
@@ -36,7 +36,7 @@ async def test_lbheartbeat(cli):
 async def test_heartbeat(cli, config, mock_aioresponses):
     config.BUGTRACKER_URL = "https://bugzilla.mozilla.org"
     mock_aioresponses.get(
-        config.BUGTRACKER_URL + "/rest/version", payload={"version": "foo"}
+        config.BUGTRACKER_URL + "/rest/whoami", payload={"name": "foo"}
     )
 
     response = await cli.get("/__heartbeat__")

--- a/tests/test_basic_endpoints.py
+++ b/tests/test_basic_endpoints.py
@@ -33,7 +33,12 @@ async def test_lbheartbeat(cli):
     assert response.status == 200
 
 
-async def test_heartbeat(cli):
+async def test_heartbeat(cli, config, mock_aioresponses):
+    config.BUGTRACKER_URL = "https://bugzilla.mozilla.org"
+    mock_aioresponses.get(
+        config.BUGTRACKER_URL + "/rest/version", payload={"version": "foo"}
+    )
+
     response = await cli.get("/__heartbeat__")
     assert response.status == 200
     body = await response.json()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -90,6 +90,23 @@ def test_extract_json():
     assert "string indices must be integers" in str(exc_info.value)
 
 
+async def test_bugzilla_ping_fallsback_to_false(mock_aioresponses, config):
+    config.BUGTRACKER_URL = "https://bugzilla.mozilla.org"
+    tracker = BugTracker()
+    result = await tracker.ping()
+    assert not result
+
+
+async def test_bugzilla_ping_returns_true_on_success(mock_aioresponses, config):
+    config.BUGTRACKER_URL = "https://bugzilla.mozilla.org"
+    tracker = BugTracker()
+    mock_aioresponses.get(
+        config.BUGTRACKER_URL + "/rest/version", payload={"version": "foo"}
+    )
+    result = await tracker.ping()
+    assert result
+
+
 async def test_bugzilla_fetch_fallsback_to_empty_list(mock_aioresponses, config):
     config.BUGTRACKER_URL = "https://bugzilla.mozilla.org"
     tracker = BugTracker()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -101,7 +101,7 @@ async def test_bugzilla_ping_returns_true_on_success(mock_aioresponses, config):
     config.BUGTRACKER_URL = "https://bugzilla.mozilla.org"
     tracker = BugTracker()
     mock_aioresponses.get(
-        config.BUGTRACKER_URL + "/rest/version", payload={"version": "foo"}
+        config.BUGTRACKER_URL + "/rest/whoami", payload={"name": "foo"}
     )
     result = await tracker.ping()
     assert result

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -114,22 +114,25 @@ async def test_bugzilla_fetch_fallsback_to_empty_list(mock_aioresponses, config)
     assert results == []
 
 
-async def test_bugzilla_fetch_fallsback_to_empty_list_with_missing_property(mock_aioresponses, config):
+async def test_bugzilla_fetch_fallsback_to_empty_list_with_missing_property(
+    mock_aioresponses, config
+):
     config.BUGTRACKER_URL = "https://bugzilla.mozilla.org"
     tracker = BugTracker()
     mock_aioresponses.get(
-        config.BUGTRACKER_URL + "/rest/bug?whiteboard=telescope ",
-        payload={}
+        config.BUGTRACKER_URL + "/rest/bug?whiteboard=telescope ", payload={}
     )
     results = await tracker.fetch(project="telemetry", name="pipeline")
     assert results == []
 
-async def test_bugzilla_fetch_fallsback_to_empty_list_with_bad_response(mock_aioresponses, config):
+
+async def test_bugzilla_fetch_fallsback_to_empty_list_with_bad_response(
+    mock_aioresponses, config
+):
     config.BUGTRACKER_URL = "https://bugzilla.mozilla.org"
     tracker = BugTracker()
     mock_aioresponses.get(
-        config.BUGTRACKER_URL + "/rest/bug?whiteboard=telescope ",
-        payload="foo"
+        config.BUGTRACKER_URL + "/rest/bug?whiteboard=telescope ", payload="foo"
     )
     results = await tracker.fetch(project="telemetry", name="pipeline")
     assert results == []

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -114,6 +114,27 @@ async def test_bugzilla_fetch_fallsback_to_empty_list(mock_aioresponses, config)
     assert results == []
 
 
+async def test_bugzilla_fetch_fallsback_to_empty_list_with_missing_property(mock_aioresponses, config):
+    config.BUGTRACKER_URL = "https://bugzilla.mozilla.org"
+    tracker = BugTracker()
+    mock_aioresponses.get(
+        config.BUGTRACKER_URL + "/rest/bug?whiteboard=telescope ",
+        payload={}
+    )
+    results = await tracker.fetch(project="telemetry", name="pipeline")
+    assert results == []
+
+async def test_bugzilla_fetch_fallsback_to_empty_list_with_bad_response(mock_aioresponses, config):
+    config.BUGTRACKER_URL = "https://bugzilla.mozilla.org"
+    tracker = BugTracker()
+    mock_aioresponses.get(
+        config.BUGTRACKER_URL + "/rest/bug?whiteboard=telescope ",
+        payload="foo"
+    )
+    results = await tracker.fetch(project="telemetry", name="pipeline")
+    assert results == []
+
+
 async def test_bugzilla_fetch_without_cache(mock_aioresponses, config):
     config.BUGTRACKER_URL = "https://bugzilla.mozilla.org"
     tracker = BugTracker()


### PR DESCRIPTION
 - Fixes #1457 - Create empty bugs array with any exception as bugzilla may return a different response than expected
 -  Fixes #1423 - Adding a bugzilla "ping" by querying the `/rest/whoami`