### PR TITLE
Add 'period_sampling_seconds' param instead of hard-coded 600 seconds

### DIFF
--- a/checks/normandy/jexl_error_rate.py
+++ b/checks/normandy/jexl_error_rate.py
@@ -19,9 +19,16 @@ DEFAULT_PLOT = ".error_rate"
 
 
 async def run(
-    max_error_percentage: float, channels: List[str] = [], period_hours: int = 6
+    max_error_percentage: float,
+    channels: List[str] = [],
+    period_hours: int = 6,
+    period_sampling_seconds: int = 600,
 ) -> CheckResult:
-    rows = await fetch_normandy_uptake(channels=channels, period_hours=period_hours)
+    rows = await fetch_normandy_uptake(
+        channels=channels,
+        period_hours=period_hours,
+        period_sampling_seconds=period_sampling_seconds,
+    )
 
     min_timestamp = min(r["min_timestamp"] for r in rows)
     max_timestamp = max(r["max_timestamp"] for r in rows)

--- a/checks/normandy/reported_recipes.py
+++ b/checks/normandy/reported_recipes.py
@@ -27,9 +27,17 @@ logger = logging.getLogger(__name__)
 
 
 async def run(
-    server: str, lag_margin: int = 600, channels: List[str] = [], period_hours: int = 6
+    server: str,
+    lag_margin: int = 600,
+    channels: List[str] = [],
+    period_hours: int = 6,
+    period_sampling_seconds: int = 600,
 ) -> CheckResult:
-    rows = await fetch_normandy_uptake(channels=channels, period_hours=period_hours)
+    rows = await fetch_normandy_uptake(
+        channels=channels,
+        period_hours=period_hours,
+        period_sampling_seconds=period_sampling_seconds,
+    )
 
     min_timestamp = min(r["min_timestamp"] for r in rows)
     max_timestamp = max(r["max_timestamp"] for r in rows)

--- a/tests/checks/remotesettings/test_uptake_error_rate.py
+++ b/tests/checks/remotesettings/test_uptake_error_rate.py
@@ -257,7 +257,13 @@ async def test_filter_on_legacy_versions_by_default(mock_aioresponses):
     ) as mocked:
         await run(max_error_percentage=0.1)
     assert mocked.call_args_list == [
-        mock.call(sources=[], channels=[], period_hours=4, min_version=(91, 5, 0))
+        mock.call(
+            sources=[],
+            channels=[],
+            period_hours=4,
+            period_sampling_seconds=600,
+            min_version=(91, 5, 0),
+        )
     ]
 
 
@@ -267,7 +273,13 @@ async def test_include_legacy_versions(mock_aioresponses):
     ) as mocked:
         await run(max_error_percentage=0.1, include_legacy_versions=True)
     assert mocked.call_args_list == [
-        mock.call(sources=[], channels=[], period_hours=4, min_version=None)
+        mock.call(
+            sources=[],
+            channels=[],
+            period_hours=4,
+            period_sampling_seconds=600,
+            min_version=None,
+        )
     ]
 
 


### PR DESCRIPTION
This parameter was only available in `checks/remotesettings/uptake_spikes.py`