### PR TITLE
Fix #1484: keep only one status per client per source and per period

### DIFF
--- a/telescope/utils.py
+++ b/telescope/utils.py
@@ -400,6 +400,7 @@ async def fetch_bigquery(sql):  # pragma: nocover
     """
     Execute specified SQL and return rows.
     """
+
     def job():
         bqclient = getattr(threadlocal, "bqclient", None)
 

--- a/telescope/utils.py
+++ b/telescope/utils.py
@@ -400,7 +400,6 @@ async def fetch_bigquery(sql):  # pragma: nocover
     """
     Execute specified SQL and return rows.
     """
-    print(sql)
     def job():
         bqclient = getattr(threadlocal, "bqclient", None)
 

--- a/telescope/utils.py
+++ b/telescope/utils.py
@@ -400,7 +400,7 @@ async def fetch_bigquery(sql):  # pragma: nocover
     """
     Execute specified SQL and return rows.
     """
-
+    print(sql)
     def job():
         bqclient = getattr(threadlocal, "bqclient", None)
 


### PR DESCRIPTION
Fix #1484

**Context**: in the client uptake telemetry code, we send one status per sync and per collection (aka source), except for attachments, where we report a download_error on each attachment download. If all downloads fail, the status is reported as many times per source as they are attachments in the collection.

This change modifies the query so that we only take into account one status per client per source and per period.

Example of configuration and run:

```toml
[checks.remotesettings-uptake-release.error-rate]
description = "Error rate of all sources"
module = "checks.remotesettings.uptake_error_rate"
params.max_error_percentage = 7
params.ignore_status = [
    # Ignore errors unrelated to the pipeline.
    "network_error",
    "offline_error",
    "shutdown_error",
]
params.channels = ["release", "esr"]
params.period_hours = 3
ttl = 7200
tags = ["telemetry", "remotesettings", "delivery-pipeline"]

```

```
$ CONFIG_FILE=config-test.toml make check project=remotesettings-uptake-release check=error-rate
```