### PR TITLE
Modify `build-publish` workflow to push to GAR

### DIFF
--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -14,20 +14,30 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     env:
-      IMAGE_NAME: mozilla/telescope
+      DOCKERHUB_IMAGE_NAME: mozilla/telescope
       TEST_CONTAINER_NAME: container-healthcheck
+      GAR_LOCATION: us
+      GCP_PROJECT_ID: telescope-prod
+      GAR_REPOSITORY: moz-fx-telescope-prod
+      IMAGE: telescope
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Fetch everything (tags)
-      - name: Set tag version
-        run: echo "VERSION_TAG=$(git describe --tags --abbrev=4)" >> $GITHUB_ENV
+
+      - id: determine_tag
+        name: determine tag
+        run: |-
+          TAG=$(git describe --tags)
+          printf "\e[1;36m[INFO]\e[0m \$TAG=\"${TAG}\"\n"
+          echo TAG=${TAG} >> ${GITHUB_OUTPUT}
+
       - name: Build `version.json` file
         run: |
           printf '{\n    "commit": "%s",\n    "version": "%s",\n    "source": "%s",\n    "build": "%s"\n}\n' \
             "$GITHUB_SHA" \
-            "$VERSION_TAG" \
+            "${{ steps.determine_tag.outputs.TAG }}" \
             "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
             "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" > ./version.json
           cat version.json
@@ -36,12 +46,33 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: |
+            ${{ env.DOCKERHUB_IMAGE_NAME }}
+            ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/${{ env.IMAGE }}
           # https://github.com/marketplace/actions/docker-metadata-action#tags-input
           tags: |
-            type=semver,pattern={{raw}}
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=sha,enable={{is_default_branch}}
+            type=raw,value=latest
+            type=raw,value=${{ steps.determine_tag.outputs.TAG }}
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - id: gcp_auth
+        name: gcp auth
+        if: github.event_name != 'pull_request'
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: access_token
+          service_account: artifact-writer@${{ env.GCP_PROJECT_ID }}.iam.gserviceaccount.com
+          workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
+
+      - name: Login to GAR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GAR_LOCATION }}-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.gcp_auth.outputs.access_token }}
 
       - name: Login to Docker Hub
         if: github.event_name != 'pull_request'
@@ -56,14 +87,14 @@ jobs:
           context: .
           load: true
           push: false
-          tags: ${{ env.IMAGE_NAME }}:test
+          tags: ${{ env.DOCKERHUB_IMAGE_NAME }}:test
 
       - name: Test from Docker
         run: |
           docker run \
           --name ${{ env.TEST_CONTAINER_NAME }}-test \
           --user root \
-          ${{ env.IMAGE_NAME }}:test \
+          ${{ env.DOCKERHUB_IMAGE_NAME }}:test \
           test
 
       - name: Spin up container
@@ -73,7 +104,7 @@ jobs:
           --detach \
           --env CONFIG_FILE=/app/tests/checks/remotesettings/config.toml \
           --publish 8000:8000 \
-          ${{ env.IMAGE_NAME }}:test
+          ${{ env.DOCKERHUB_IMAGE_NAME }}:test
 
       - name: Check that container is running
         run: |
@@ -90,3 +121,5 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Maintains current behavior of pushing to Dockerhub, but additionally pushes to GAR