### PR TITLE
Fixing telescope push timestamp check

### DIFF
--- a/checks/remotesettings/push_timestamp.py
+++ b/checks/remotesettings/push_timestamp.py
@@ -10,10 +10,8 @@ import logging
 
 import websockets
 
-from operator import attrgetter
 from telescope.typings import CheckResult
 from telescope.utils import utcfromtimestamp, utcnow
-from datetime import datetime
 
 from .utils import KintoClient
 

--- a/checks/remotesettings/push_timestamp.py
+++ b/checks/remotesettings/push_timestamp.py
@@ -10,8 +10,10 @@ import logging
 
 import websockets
 
+from operator import attrgetter
 from telescope.typings import CheckResult
 from telescope.utils import utcfromtimestamp, utcnow
+from datetime import datetime
 
 from .utils import KintoClient
 
@@ -43,6 +45,10 @@ async def get_push_timestamp(uri) -> str:
 async def get_remotesettings_timestamp(uri) -> str:
     client = KintoClient(server_url=uri)
     entries = await client.get_monitor_changes(bust_cache=True)
+
+    # sort by timestamp desc as the records are returned by bucket/collection
+    entries.sort(key=lambda e: e["last_modified"], reverse=True)
+
     # Some collections are excluded (eg. preview)
     # https://github.com/mozilla-services/cloudops-deployment/blob/master/projects/kinto/puppet/modules/kinto/templates/kinto.ini.erb
     matched = [e for e in entries if "preview" not in e["bucket"]]

--- a/tests/checks/remotesettings/test_push_timestamp.py
+++ b/tests/checks/remotesettings/test_push_timestamp.py
@@ -18,7 +18,8 @@ async def test_positive(mock_responses):
         payload={
             "changes": [
                 {"id": "a", "bucket": "main-preview", "last_modified": 2000000000000},
-                {"id": "b", "bucket": "main", "last_modified": 1573086234731},
+                {"id": "b", "bucket": "main", "last_modified": 1273086234731},
+                {"id": "c", "bucket": "main", "last_modified": 1573086234731},
             ]
         },
     )


### PR DESCRIPTION
We updated the kinto client library and started using the changeset endpoint.
However that endpoint returns records sorted by bucket and collection name, causing this check to be a false positive.
Sorting the records by `last_modified` first makes this check work and prevents us from hitting this banana peel in the future.