### PR TITLE
Skip failing login on fork PRs

### DIFF
--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -70,6 +70,7 @@ jobs:
           workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
 
       - name: Login to GAR
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.GAR_LOCATION }}-docker.pkg.dev
@@ -77,6 +78,7 @@ jobs:
           password: ${{ steps.gcp_auth.outputs.access_token }}
 
       - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
This should fix the failing login on Docker on Dependabot PRs