### PR TITLE
(wip) Add CDN usage check

### DIFF
--- a/checks/remotesettings/cdn_usage.py
+++ b/checks/remotesettings/cdn_usage.py
@@ -1,0 +1,213 @@
+"""
+Analyze the CDN usage of Remote Settings.
+
+For each endpoint, the top 5 collections by bandwidth and hits are returned.
+"""
+
+import json
+import os
+
+from telescope.typings import CheckResult
+from telescope.utils import fetch_bigquery
+
+
+QUERY = """
+WITH attachments_urls AS (
+  SELECT
+    'attachments' AS source,
+    http_request.request_url AS url,
+    http_request.response_size AS size,
+    *
+  FROM `moz-fx-remote-settings-prod.remote_settings_prod_default_log_linked._AllLogs`
+  WHERE http_request.request_url LIKE '{attachments_base_url}%' -- exclude bad URLs
+),
+api_urls AS (
+  SELECT
+    'api' AS source,
+    http_request.request_url AS url,
+    http_request.response_size AS size,
+    *
+  FROM `moz-fx-remote-settings-prod.gke_remote_settings_prod_log_linked._AllLogs`
+  WHERE http_request.request_url LIKE '{api_base_url}%'  -- exclude writers, etc.
+),
+urls AS (
+  SELECT * FROM attachments_urls
+  UNION ALL
+  SELECT * FROM api_urls
+),
+urls_with_endpoint AS (
+  SELECT
+  CASE
+    WHEN url LIKE '%/v1/' THEN 'root'
+    WHEN url LIKE '%/bundles/%' THEN 'bundles'
+    WHEN url LIKE '{attachments_base_url}/%/%/%' THEN 'attachments'
+    WHEN url LIKE '%/records%' THEN 'records'
+    WHEN url LIKE '%/changeset%' AND url LIKE '%collection=%' THEN 'filtered-monitor'
+    WHEN url LIKE '%/changeset%' THEN 'changeset'
+    WHEN url LIKE '%/collections/%' THEN 'collection'
+    ELSE 'unknown'
+  END AS endpoint,
+  *
+  FROM urls
+  WHERE timestamp >= TIMESTAMP(DATE_TRUNC(DATE_SUB(CURRENT_DATE(), INTERVAL 1 MONTH), MONTH))
+    AND timestamp < TIMESTAMP(DATE_TRUNC(CURRENT_DATE(), MONTH))
+    AND http_request.status = 200
+),
+urls_with_types_bid_cid AS (
+  SELECT
+  CASE
+    WHEN endpoint = 'bundles' THEN REGEXP_EXTRACT(url, r'/bundles/([^\\.]+)')
+    WHEN endpoint = 'attachments' THEN REGEXP_EXTRACT(url, r'https://[^/]+/([^/]+)/[^/]+/[^/]+')
+    WHEN endpoint = 'filtered-monitor' THEN REGEXP_EXTRACT(url, r'bucket=([^&]+)')
+    ELSE REGEXP_EXTRACT(url, r'/buckets/([^/]+)/')
+  END AS bid,
+  CASE
+    WHEN endpoint = 'bundles' THEN REGEXP_EXTRACT(url, r'/bundles/([^\\.]+)')
+    WHEN endpoint = 'attachments' THEN REGEXP_EXTRACT(url, r'https://[^/]+/[^/]+/([^/]+)/[^/]+')
+    WHEN endpoint = 'filtered-monitor' THEN REGEXP_EXTRACT(url, r'collection=([^&]+)')
+    ELSE REGEXP_EXTRACT(url, r'/collections/([^/?]+)')
+  END AS cid,
+  *
+  FROM urls_with_endpoint
+),
+period AS (
+  SELECT
+    FORMAT_TIMESTAMP('%FT%T%Ez', MIN(timestamp)) AS period_start,
+    FORMAT_TIMESTAMP('%FT%T%Ez', MAX(timestamp)) AS period_end
+  FROM urls_with_endpoint
+),
+total_size_hits_by_cid AS (
+  SELECT
+    source,
+    endpoint,
+    REPLACE(
+        REPLACE(
+            REPLACE(bid, "-staging", ""),
+            "staging", "blocklists"
+        ),
+        "-workspace", ""
+    ) AS bid,
+    COALESCE(SPLIT(cid, '--')[SAFE_OFFSET(1)], cid) AS cid,
+    SUM(size) AS size,
+    COUNT(*) AS hits
+  FROM urls_with_types_bid_cid
+  GROUP BY
+    source,
+    endpoint,
+    bid,
+    cid
+),
+totals_by_source AS (
+  SELECT source, SUM(size) AS total_size, COUNT(*) AS total_hits
+  FROM urls_with_endpoint
+  GROUP BY source
+)
+SELECT
+  period_start,
+  period_end,
+  bid AS bucket_id,
+  cid AS collection_id,
+  t1.source,
+  t1.endpoint,
+  hits,
+  size,
+  total_hits,
+  total_size
+FROM
+  period,
+  total_size_hits_by_cid AS t1
+    LEFT JOIN totals_by_source AS t2
+    ON (t1.source = t2.source)
+WHERE t1.hits > 2 -- ignore noise (not real clients)
+"""
+
+
+async def run(
+    project: str = "moz-fx-remote-settings-prod",
+    top_count: int = 5,
+    api_base_url="https://firefox.settings.services.mozilla.com/v1",
+    attachments_base_url="https://firefox-settings-attachments.cdn.mozilla.net",
+) -> CheckResult:
+    query = QUERY.format(
+        api_base_url=api_base_url, attachments_base_url=attachments_base_url
+    )
+    print(query)
+    if os.path.exists("results.json"):
+        with open("results.json", "r") as f:
+            rows = json.load(f)
+    else:
+        rows = await fetch_bigquery(query, project=project)
+        rows = [dict(row) for row in rows]
+        with open("results.json", "w") as f:
+            json.dump(rows, f, indent=4)
+
+    # Compute the total of bandwidth and hits per endpoint.
+    totals = {}
+    for row in rows:
+        endpoint = row["endpoint"]
+        totals.setdefault(
+            endpoint,
+            {
+                "bandwidth": 0,
+                "hits": 0,
+            },
+        )
+        totals[endpoint]["bandwidth"] += row["size"]
+        totals[endpoint]["hits"] += row["hits"]
+    # Combine all endpoints into a single `__all__` entry.
+    totals["__all__"] = {
+        "bandwidth": sum(row["bandwidth"] for row in totals.values()),
+        "hits": sum(row["hits"] for row in totals.values()),
+    }
+
+    tops_bandwidth_per_endpoint = {}
+    tops_hits_per_endpoint = {}
+    for endpoint in totals.keys():
+        # Sum the bandwidth and hits per collection.
+        per_collection = {}
+        for row in rows:
+            if row["endpoint"] == "unknown":
+                # Omit the unknown endpoints, since no collection is associated with them.
+                continue
+            if row["endpoint"] != endpoint and endpoint != "__all__":
+                # Filter rows by endpoint to sum, unless it's the `__all__` entry.
+                continue
+            if row["endpoint"] == "root":
+                cid = "root"
+            elif row["endpoint"] == "bundles":
+                cid = row["collection_id"]
+            else:
+                cid = f"{row['bucket_id']}/{row['collection_id']}"
+
+            per_collection.setdefault(cid, {"bandwidth": 0, "hits": 0})
+            per_collection[cid]["bandwidth"] += row["size"]
+            per_collection[cid]["hits"] += row["hits"]
+
+        # Keep only the top 5 collections by bandwidth and hits.
+        tops_bandwidth_per_endpoint[endpoint] = {
+            cid: round(100.0 * value["bandwidth"] / totals[endpoint]["bandwidth"], 2)
+            for cid, value in sorted(
+                per_collection.items(), key=lambda x: x[1]["bandwidth"], reverse=True
+            )[:top_count]
+        }
+        tops_hits_per_endpoint[endpoint] = {
+            cid: round(100.0 * value["hits"] / totals[endpoint]["hits"], 2)
+            for cid, value in sorted(
+                per_collection.items(), key=lambda x: x[1]["hits"], reverse=True
+            )[:top_count]
+        }
+
+    # Remove the 'root' and 'unknown' endpoints from the top percentages,
+    # since they are not collections.
+    for endpoint in ("root", "unknown"):
+        del tops_bandwidth_per_endpoint[endpoint]
+        del tops_hits_per_endpoint[endpoint]
+
+    result = {
+        "period_start": rows[0]["period_start"],
+        "period_end": rows[0]["period_end"],
+        "bandwidth": tops_bandwidth_per_endpoint,
+        "hits": tops_hits_per_endpoint,
+    }
+
+    return True, result

--- a/telescope/utils.py
+++ b/telescope/utils.py
@@ -401,7 +401,7 @@ class EventEmitter:
         self.callbacks.setdefault(event, []).append(callback)
 
 
-async def fetch_bigquery(sql):  # pragma: nocover
+async def fetch_bigquery(sql, project=config.HISTORY_PROJECT_ID):  # pragma: nocover
     """
     Execute specified SQL and return rows.
     """
@@ -411,7 +411,7 @@ async def fetch_bigquery(sql):  # pragma: nocover
 
         if bqclient is None:
             # Reads credentials from env and connects.
-            bqclient = bigquery.Client(project=config.HISTORY_PROJECT_ID)
+            bqclient = bigquery.Client(project=project)
 
             setattr(threadlocal, "bqclient", bqclient)
 


### PR DESCRIPTION
This query returns the top collections in terms of percentages of bandwidth and hits.
It details per endpoint, and sums all endpoint in `__all__`.

It doesn't show absolute values (total hits, or total bandwidth) so that it can be exposed in our Telescope instance.

I'll get some help to build a private Looker dashboard too, but I thought it could be handy to look at this through Telescope.
For example, if we know the cost of CDN last month, we can turn this into absolute cost value:
```
$ curl https://telescope.prod.webservices.mozgcp.net/checks/remotesettings-prod/cdn-usage | \
     jq '.data.bandwidth["__all__"] \
         | to_entries \
         | map({key: .key, value: (.value * $TOTAL_COST / 100 | round)}) \
         | from_entries'
         
{
  "main/nimbus-desktop-experiments": 1357,
  "security-state/intermediates": 1002,
  "monitor/changes": 455,
  "security-state/onecrl": 287,
  "intermediates": 235
}
```

Question: will our telescope SA have the perms to query this dataset 🤷 

Any first thoughts?


```
{
  "period_start": "2025-04-01T00:00:00+00:00",
  "period_end": "2025-04-30T23:59:59+00:00",
  "bandwidth": {
    "records": {
      "main/nimbus-mobile-experiments": 57.38,
      "main/search-telemetry-v2": 27.84,
      "monitor/changes": 5.97,
      "blocklists/addons": 1.98,
      "main/fxmonitor-breaches": 1.72
    },
    "filtered-monitor": {
      "main/nimbus-desktop-experiments": 50.57,
      "main/nimbus-secure-experiments": 25.08,
      "main/query-stripping": 5.28,
      "main/fingerprinting-protection-overrides": 3.31,
      "main/partitioning-exempt-urls": 3.26
    },
    "collection": {
      "main/search-config": 10.71,
      "blocklists/gfx": 10.69,
      "main/cookie-banner-rules-list": 9.1,
      "main/hijack-blocklists": 7.88,
      "main/search-config-overrides-v2": 7.13
    },
    "attachments": {
      "security-state/cert-revocations": 32.08,
      "main/tracking-protection-lists": 26.36,
      "main/newtab-wallpapers-v2": 18.44,
      "main/translations-models": 11.91,
      "security-state/intermediates": 4.46
    },
    "changeset": {
      "main/nimbus-desktop-experiments": 32.24,
      "security-state/intermediates": 23.82,
      "monitor/changes": 10.31,
      "security-state/onecrl": 6.73,
      "main/fxmonitor-breaches": 4.62
    },
    "bundles": {
      "intermediates": 69.47,
      "startup": 30.52,
      "changesets": 0.01
    },
    "__all__": {
      "security-state/cert-revocations": 17.33,
      "main/tracking-protection-lists": 14.02,
      "main/nimbus-desktop-experiments": 13.57,
      "security-state/intermediates": 12.27,
      "main/newtab-wallpapers-v2": 9.34
    }
  },
  "hits": {
    "records": {
      "main/search-telemetry-v2": 31.57,
      "main/ms-language-packs": 28.94,
      "main/quicksuggest": 24.41,
      "main/nimbus-mobile-experiments": 6.82,
      "monitor/changes": 5.34
    },
    "filtered-monitor": {
      "main/nimbus-desktop-experiments": 41.44,
      "main/nimbus-secure-experiments": 32.81,
      "main/query-stripping": 4.9,
      "main/partitioning-exempt-urls": 3.71,
      "main/fingerprinting-protection-overrides": 3.03
    },
    "collection": {
      "main/hijack-blocklists": 13.78,
      "main/anti-tracking-url-decoration": 7.69,
      "main/sites-classification": 7.66,
      "main/password-recipes": 7.48,
      "main/language-dictionaries": 7.31
    },
    "attachments": {
      "security-state/intermediates": 67.71,
      "main/search-config-icons": 12.72,
      "security-state/cert-revocations": 7.9,
      "main/tracking-protection-lists": 5.33,
      "main/quicksuggest": 2.83
    },
    "changeset": {
      "monitor/changes": 39.06,
      "main/nimbus-desktop-experiments": 11.77,
      "security-state/cert-revocations": 5.78,
      "main/devtools-compatibility-browsers": 2.61,
      "security-state/intermediates": 2.42
    },
    "bundles": {
      "startup": 87.99,
      "intermediates": 12.01,
      "changesets": 0.0
    },
    "__all__": {
      "security-state/intermediates": 31.63,
      "monitor/changes": 13.11,
      "main/nimbus-desktop-experiments": 7.25,
      "main/search-config-icons": 6.06,
      "security-state/cert-revocations": 5.47
    }
  }
}
```