### PR TITLE
Ref #1585 - Adjusting fetch_signed_resources to only throw MissingFromMonitorChangesError for monitored collections

### DIFF
--- a/checks/remotesettings/utils.py
+++ b/checks/remotesettings/utils.py
@@ -181,8 +181,16 @@ async def fetch_signed_resources(server_url: str, auth: str) -> List[Dict[str, D
         resources.append(r)
 
     # Check that all source collections were found in the monitored changes.
+    try:
+        monitored_collections = info["capabilities"]["changes"]["collections"]
+    except KeyError:
+        monitored_collections = []
     for bid, cid in all_source_collections:
-        raise MissingFromMonitorChangesError(bid, cid)
+        if (
+            f"/buckets/{bid}" in monitored_collections
+            or f"/buckets/{bid}/collections/{cid}" in monitored_collections
+        ):
+            raise MissingFromMonitorChangesError(bid, cid)
 
     return resources
 

--- a/tests/checks/remotesettings/test_collections_consistency.py
+++ b/tests/checks/remotesettings/test_collections_consistency.py
@@ -250,7 +250,8 @@ async def test_fails_if_source_collection_missing_in_monitored_changes(
                             "destination": {"bucket": "bid", "collection": None},
                         }
                     ]
-                }
+                },
+                "changes": {"collections": ["/buckets/bid-workspace"]},
             }
         },
     )


### PR DESCRIPTION
Ref #1585 - Adjusting fetch_signed_resources to only throw MissingFromMonitorChangesError for monitored collections.
Updated unit test.