### PR TITLE
Fix remote-settings issue #1018 - Removed unnecesary days calculation in signatures_age check, we already do total_seconds

### DIFF
--- a/checks/remotesettings/signatures_age.py
+++ b/checks/remotesettings/signatures_age.py
@@ -22,7 +22,7 @@ async def get_signature_age_hours(client, bucket, collection):
     signature_date = data["last_signature_date"]
     dt = datetime.fromisoformat(signature_date)
     delta = utcnow() - dt
-    age = int(delta.days * 24 + delta.total_seconds() / 3600)
+    age = int(delta.total_seconds() / 3600)
     return age
 
 


### PR DESCRIPTION
Fixes [#1018](https://github.com/mozilla/remote-settings/issues/1018) from remote-settings.

We were effectively doubling the hours in this calculation, since `total_seconds()` would include the full value already.